### PR TITLE
Added codec-list option for entrypoint

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -85,6 +85,15 @@ while :; do
     sed -i -e "s/inbound-codec-negotiation\" value=\"greedy/inbound-codec-negotiation\" value=\"generous"/g /usr/local/freeswitch/conf/sip_profiles/mrf.xml
     shift
     ;;
+  
+  --codec-list)
+    if [ -n "$2" ]; then
+      sed -i -e "s/global_codec_prefs=.*\"/global_codec_prefs=$2\"/g" /usr/local/freeswitch/conf/vars.xml
+      sed -i -e "s/outbound_codec_prefs=.*\"/outbound_codec_prefs=$2\"/g" /usr/local/freeswitch/conf/vars.xml
+    fi
+    shift
+    shift
+    ;;
 
   --advertise-external-ip)
     sed -i -e "s/ext-sip-ip\" value=\".*\"/ext-sip-ip\" value=\"\$\${ext_sip_ip}\""/g /usr/local/freeswitch/conf/sip_profiles/mrf.xml


### PR DESCRIPTION
Entrypoint script now accepts a `codec-list` parameter that updates the default accepted codec list on /usr/local/freeswitch/conf/vars.xml

