### PR TITLE
Allow for replacing the RTP ports

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -43,7 +43,7 @@ while :; do
 
   -a|--rtp-range-start)
     if [ -n "$2" ]; then
-      sed -i -e "s/name=\"rtp-start-port\" value=\"16384\"/name=\"rtp-start-port\" value=\"$2\"/g" /usr/local/freeswitch/conf/autoload_configs/switch.conf.xml
+      sed -i -e "s/name=\"rtp-start-port\" value=\".*\"/name=\"rtp-start-port\" value=\"$2\"/g" /usr/local/freeswitch/conf/autoload_configs/switch.conf.xml
     fi
     shift
     shift
@@ -51,7 +51,7 @@ while :; do
 
   -z|--rtp-range-end)
     if [ -n "$2" ]; then
-      sed -i -e "s/name=\"rtp-end-port\" value=\"32768\"/name=\"rtp-end-port\" value=\"$2\"/g" /usr/local/freeswitch/conf/autoload_configs/switch.conf.xml
+      sed -i -e "s/name=\"rtp-end-port\" value=\".*\"/name=\"rtp-end-port\" value=\"$2\"/g" /usr/local/freeswitch/conf/autoload_configs/switch.conf.xml
     fi
     shift
     shift


### PR DESCRIPTION
The `socket.conf.xml` may not have that values in the image (`16384` and `32768`). RIght now, the argument won't change the file because it has the following content:

```
<param name="rtp-start-port" value="25000"/>
<param name="rtp-end-port" value="39000"/>
```

This PR will prevent this problem in the future by using a regex for ignoring changes in the default port numbers.