### PR TITLE
Use sip_port and tls_port vars

### DIFF
--- a/files/sip_profiles/mrf.xml
+++ b/files/sip_profiles/mrf.xml
@@ -13,7 +13,7 @@
       <param name="inbound-late-negotiation" value="true"/>
       <param name="rtp-ip" value="$${local_ip_v4}"/>
       <param name="sip-ip" value="$${local_ip_v4}"/>
-      <param name="sip-port" value="5080"/>
+      <param name="sip-port" value="$${sip_port}"/>
       <param name="ext-rtp-ip" value="$${local_ip_v4}"/>
       <param name="ext-sip-ip" value="$${local_ip_v4}"/>
       <param name="auth-calls" value="false"/>
@@ -33,13 +33,13 @@
       <param name="enable-3pcc" value="true"/>
 
       <!-- TLS: enabled by default, set to "false" to disable -->
-      <param name="tls" value="false"/>
+      <param name="tls" value="true"/>
       <!-- Set to true to not bind on the normal sip-port but only on the TLS port -->
       <param name="tls-only" value="false"/>
       <!-- additional bind parameters for TLS -->
       <param name="tls-bind-params" value="transport=tls"/>
       <!-- Port to listen on for TLS requests. (5061 will be used if unspecified) -->
-      <param name="tls-sip-port" value="5061"/>
+      <param name="tls-sip-port" value="$${tls_port}"/>
       <!-- Location of the agent.pem and cafile.pem ssl certificates (needed for TLS server) -->
       <!--<param name="tls-cert-dir" value="/usr/local/freeswitch/certs"/>-->
       <!-- Optionally set the passphrase password used by openSSL to encrypt/decrypt TLS private key files -->


### PR DESCRIPTION
I noticed this latest version of the container does not respect the sip_port or tls_port settings. Also TLS was off, whereas in the past it's been on.