### PR TITLE
improve dockerfile, add env, add changelog, add local build script

### DIFF
--- a/.env
+++ b/.env
@@ -10,4 +10,4 @@ spandspVersion=0d2e6ac # https://github.com/freeswitch/spandsp/commit/0d2e6ac65e
 sofiaVersion=1.13.17
 awsSdkCppVersion=1.11.345
 freeswitchModulesVersion=1.2.15
-freeswitchVersion=1.10.10
+freeswitchVersion=1.10.11

--- a/.env
+++ b/.env
@@ -3,7 +3,7 @@
 ## and docker build does not support any quotes in image tag.
 
 cmakeVersion=3.28.3
-grpcVersion=1.57.0
+grpcVersion=1.64.2
 websocketsVersion=4.3.3
 speechSdkVersion=1.37.0
 spandspVersion=0d2e6ac # https://github.com/freeswitch/spandsp/commit/0d2e6ac65e0e8f53d652665a743015a88bf048d4

--- a/.env
+++ b/.env
@@ -4,7 +4,7 @@
 
 cmakeVersion=3.28.3
 grpcVersion=1.64.2
-websocketsVersion=4.3.3
+libwebsocketsVersion=4.3.3
 speechSdkVersion=1.37.0
 spandspVersion=0d2e6ac # https://github.com/freeswitch/spandsp/commit/0d2e6ac65e0e8f53d652665a743015a88bf048d4
 sofiaVersion=1.13.17

--- a/.env
+++ b/.env
@@ -1,0 +1,13 @@
+## Please don't use any single quotes or double quotes.
+## Literal values after the equal sign will be passed to the docker build command
+## and docker build does not support any quotes in image tag.
+
+cmakeVersion=3.28.3
+grpcVersion=1.57.0
+websocketsVersion=4.3.3
+speechSdkVersion=1.37.0
+spandspVersion=0d2e6ac # https://github.com/freeswitch/spandsp/commit/0d2e6ac65e0e8f53d652665a743015a88bf048d4
+sofiaVersion=1.13.17
+awsSdkCppVersion=1.11.345
+freeswitchModulesVersion=1.2.15
+freeswitchVersion=1.10.10

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,6 +17,34 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Read the value of the cmake version
+        run: echo "##vso[task.setvariable variable=cmakeVersion]$(grep cmakeVersion $(Build.Repository.LocalPath)/.env | awk -F '=' '{print $2}')"
+        shell: bash
+      - name: Read the value of the grpc version
+        run: echo "##vso[task.setvariable variable=grpcVersion]$(grep grpcVersion $(Build.Repository.LocalPath)/.env | awk -F '=' '{print $2}')"
+        shell: bash
+      - name: Read the value of the websocket version
+        run: echo "##vso[task.setvariable variable=websocketsVersion]$(grep websocketsVersion $(Build.Repository.LocalPath)/.env | awk -F '=' '{print $2}')"
+        shell: bash
+      - name: Read the value of the speech SDK version
+        run: echo "##vso[task.setvariable variable=speechSdkVersion]$(grep speechSdkVersion $(Build.Repository.LocalPath)/.env | awk -F '=' '{print $2}')"
+        shell: bash
+      - name: Read the value of the spandsp version
+        run: echo "##vso[task.setvariable variable=spandspVersion]$(grep spandspVersion $(Build.Repository.LocalPath)/.env | awk -F '=' '{print $2}')"
+        shell: bash
+      - name: Read the value of the sofia version
+        run: echo "##vso[task.setvariable variable=sofiaVersion]$(grep sofiaVersion $(Build.Repository.LocalPath)/.env | awk -F '=' '{print $2}')"
+        shell: bash
+      - name: Read the value of the aws SDK CPP version
+        run: echo "##vso[task.setvariable variable=awsSdkCppVersion]$(grep awsSdkCppVersion $(Build.Repository.LocalPath)/.env | awk -F '=' '{print $2}')"
+        shell: bash      
+      - name: Read the value of the freeswitch modules version
+        run: echo "##vso[task.setvariable variable=freeswitchModulesVersion]$(grep freeswitchModulesVersion $(Build.Repository.LocalPath)/.env | awk -F '=' '{print $2}')"
+        shell: bash
+      - name: Read the value of the freeswitch version
+        run: echo "##vso[task.setvariable variable=freeswitchVersion]$(grep freeswitchVersion $(Build.Repository.LocalPath)/.env | awk -F '=' '{print $2}')"
+        shell: bash
+
       - name: prepare tag 
         id: prepare_tag
         run: |

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,8 +23,8 @@ jobs:
       - name: Read the value of the grpc version
         run: echo "##vso[task.setvariable variable=grpcVersion]$(grep grpcVersion $(Build.Repository.LocalPath)/.env | awk -F '=' '{print $2}')"
         shell: bash
-      - name: Read the value of the websocket version
-        run: echo "##vso[task.setvariable variable=websocketsVersion]$(grep websocketsVersion $(Build.Repository.LocalPath)/.env | awk -F '=' '{print $2}')"
+      - name: Read the value of the libwebsocketsVersion version
+        run: echo "##vso[task.setvariable variable=libwebsocketsVersion]$(grep libwebsocketsVersion $(Build.Repository.LocalPath)/.env | awk -F '=' '{print $2}')"
         shell: bash
       - name: Read the value of the speech SDK version
         run: echo "##vso[task.setvariable variable=speechSdkVersion]$(grep speechSdkVersion $(Build.Repository.LocalPath)/.env | awk -F '=' '{print $2}')"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - update `freeswitch` to `1.10.11`
   - this changes the `sofia-sip` library requirement to version `1.13.17`
 - update `aws-sdk-cpp` to `1.11.345`
+- update `gRPC` to `1.64.2`
 - improve `Dockerfile`
   All used versions for this build are now centralized in the `.env` file
 - improve `Dockerfile` for `sofia-sip` and use tag instead of branch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+### 0.9.1 (2024-06-08)
+- update `freeswitch` to `1.10.11`
+  - this changes the `sofia-sip` library requirement to version `1.13.17`
+- update `aws-sdk-cpp` to `1.11.345`
+- improve `Dockerfile`
+  All used versions for this build are now centralized in the `.env` file
+- improve `Dockerfile` for `sofia-sip` and use tag instead of branch
+- improve `Dockerfile` for `aws-sdk-cpp` and use tag instead of branch
+- improve `Dockerfile` for `freeswitch` and use tag instead of branch
+- update the `docker-publish` pipeline to read and set the appropriate build args
+- update `README` and add section of how to build the image locally
+- add bash script `build-locally`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - improve `Dockerfile` for `sofia-sip` and use tag instead of branch
 - improve `Dockerfile` for `aws-sdk-cpp` and use tag instead of branch
 - improve `Dockerfile` for `freeswitch` and use tag instead of branch
+- improve `Dockerfile` for `libwebsockets` and use tag instead of branch
 - update the `docker-publish` pipeline to read and set the appropriate build args
 - update `README` and add section of how to build the image locally
 - add bash script `build-locally`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,6 @@
 - improve `Dockerfile`
   All used versions for this build are now centralized in the `.env` file
 - improve `Dockerfile` for `sofia-sip` and use tag instead of branch
-- improve `Dockerfile` for `aws-sdk-cpp` and use tag instead of branch
-- improve `Dockerfile` for `freeswitch` and use tag instead of branch
-- improve `Dockerfile` for `libwebsockets` and use tag instead of branch
 - update the `docker-publish` pipeline to read and set the appropriate build args
 - update `README` and add section of how to build the image locally
 - add bash script `build-locally`

--- a/Dockerfile
+++ b/Dockerfile
@@ -169,7 +169,7 @@ COPY --from=websockets /usr/local/include/ /usr/local/include/
 COPY --from=websockets /usr/local/lib/ /usr/local/lib/
 WORKDIR /usr/local/src
 ENV LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH}
-RUN git clone -b v$FREESWITCH_VERSION https://github.com/signalwire/freeswitch.git
+RUN git clone --depth 1 -b v$FREESWITCH_VERSION https://github.com/signalwire/freeswitch.git
 COPY --from=freeswitch-modules /usr/local/src/freeswitch-modules/ /usr/local/src/freeswitch/src/mod/applications/
 COPY --from=nuance-asr-grpc-api /usr/local/src/nuance-asr-grpc-api /usr/local/src/freeswitch/libs/nuance-asr-grpc-api
 COPY --from=riva-asr-grpc-api /usr/local/src/riva-asr-grpc-api /usr/local/src/freeswitch/libs/riva-asr-grpc-api

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,18 @@
 FROM debian:bullseye-slim AS base
+
 ARG BUILD_CPUS=1
+
+## # this will be populated from the vaule in .env file
+ARG CMAKE_VERSION 
+ARG GRPC_VERSION
+ARG WEBSOCKETS_VERSION
+ARG SPEECH_SDK_VERSION
+ARG SPANDSP_VERSION
+ARG SOFIA_VERSION
+ARG AWS_SDK_CPP_VERSION
+ARG FREESWITCH_MODULES_VERSION
+ARG FREESWITCH_VERSION
+
 RUN for i in $(seq 1 8); do mkdir -p "/usr/share/man/man${i}"; done \
     && apt-get update && apt-get -y --quiet --allow-remove-essential upgrade \
     && apt-get install -y --quiet --no-install-recommends \
@@ -17,7 +30,7 @@ RUN for i in $(seq 1 8); do mkdir -p "/usr/share/man/man${i}"; done \
 
 FROM base AS base-cmake
 WORKDIR /usr/local/src
-RUN export CMAKE_VERSION=3.28.3 \
+RUN export CMAKE_VERSION=$CMAKE_VERSION \
     && wget https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-x86_64.sh \
     && chmod +x cmake-${CMAKE_VERSION}-linux-x86_64.sh \
     && ./cmake-${CMAKE_VERSION}-linux-x86_64.sh --skip-license --prefix=/usr/local \
@@ -26,7 +39,7 @@ RUN export CMAKE_VERSION=3.28.3 \
 
 FROM base-cmake AS grpc
 WORKDIR /usr/local/src
-RUN git clone --depth 1 --branch v1.57.0 https://github.com/grpc/grpc && cd grpc \
+RUN git clone --depth 1 --branch v$GRPC_VERSION https://github.com/grpc/grpc && cd grpc \
     && git submodule update --init --recursive
 RUN cd grpc \
     && mkdir -p cmake/build \
@@ -73,16 +86,16 @@ RUN git clone --depth 1 --branch main https://github.com/drachtio/cobalt-asr-grp
 FROM base-cmake AS websockets
 WORKDIR /usr/local/src
 ENV LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH}
-RUN git clone --depth 1 --branch v4.3.3 https://github.com/warmcat/libwebsockets.git \
+RUN git clone --depth 1 --branch v$WEBSOCKETS_VERSION https://github.com/warmcat/libwebsockets.git \
     && cd /usr/local/src/libwebsockets \
     && mkdir -p build && cd build && cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo && make && make install
 
 FROM base AS speechsdk
-COPY ./files/SpeechSDK-Linux-1.37.0.tar.gz /tmp/
+COPY ./files/SpeechSDK-Linux-$SPEECH_SDK_VERSION.tar.gz /tmp/
 WORKDIR /tmp
 ENV LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH}
-RUN tar xvfz SpeechSDK-Linux-1.37.0.tar.gz \
-    && cd SpeechSDK-Linux-1.37.0 \
+RUN tar xvfz SpeechSDK-Linux-$SPEECH_SDK_VERSION.tar.gz \
+    && cd SpeechSDK-Linux-$SPEECH_SDK_VERSION \
     && cp -r include /usr/local/include/MicrosoftSpeechSDK \
     && cp -r lib/ /usr/local/lib/MicrosoftSpeechSDK \
     && cp /usr/local/lib/MicrosoftSpeechSDK/x64/libMicrosoft.*.so /usr/local/lib/ \
@@ -90,7 +103,7 @@ RUN tar xvfz SpeechSDK-Linux-1.37.0.tar.gz \
 
 FROM base AS freeswitch-modules
 WORKDIR /usr/local/src
-RUN git clone --depth 1 https://github.com/jambonz/freeswitch-modules.git -b 1.2.15
+RUN git clone --depth 1 https://github.com/jambonz/freeswitch-modules.git -b $FREESWITCH_MODULES_VERSION
 
 FROM base AS spandsp
 WORKDIR /usr/local/src
@@ -101,7 +114,7 @@ RUN git clone https://github.com/freeswitch/spandsp.git && cd spandsp && git che
 FROM base AS sofia-sip
 WORKDIR /usr/local/src
 ENV LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH}
-RUN git clone --depth 1 --branch master https://github.com/freeswitch/sofia-sip.git \
+RUN git clone --depth 1 https://github.com/freeswitch/sofia-sip.git -b v$SOFIA_VERSION \
     && cd sofia-sip \
     && ./bootstrap.sh && ./configure && make -j ${BUILD_CPUS} && make install
 
@@ -115,7 +128,7 @@ RUN git clone --depth 1 https://github.com/dpirch/libfvad.git \
 FROM base-cmake AS aws-sdk-cpp
 WORKDIR /usr/local/src
 ENV LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH}
-RUN git clone --depth 1 --branch 1.11.283 https://github.com/aws/aws-sdk-cpp.git \
+RUN git clone --depth 1 https://github.com/aws/aws-sdk-cpp.git -b $AWS_SDK_CPP_VERSION \
     && cd aws-sdk-cpp \
     && git submodule update --init --recursive
 RUN cd /usr/local/src/aws-sdk-cpp \
@@ -156,7 +169,7 @@ COPY --from=websockets /usr/local/include/ /usr/local/include/
 COPY --from=websockets /usr/local/lib/ /usr/local/lib/
 WORKDIR /usr/local/src
 ENV LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH}
-RUN git clone --depth 1 --branch v1.10.10 https://github.com/signalwire/freeswitch.git
+RUN git clone --depth 1 https://github.com/signalwire/freeswitch.git -b v$FREESWITCH_VERSION
 COPY --from=freeswitch-modules /usr/local/src/freeswitch-modules/ /usr/local/src/freeswitch/src/mod/applications/
 COPY --from=nuance-asr-grpc-api /usr/local/src/nuance-asr-grpc-api /usr/local/src/freeswitch/libs/nuance-asr-grpc-api
 COPY --from=riva-asr-grpc-api /usr/local/src/riva-asr-grpc-api /usr/local/src/freeswitch/libs/riva-asr-grpc-api

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN export CMAKE_VERSION=$CMAKE_VERSION \
 
 FROM base-cmake AS grpc
 WORKDIR /usr/local/src
-RUN git clone --depth 1 https://github.com/grpc/grpc -b v$GRPC_VERSION && cd grpc \
+RUN git clone --depth 1 -b v$GRPC_VERSION https://github.com/grpc/grpc && cd grpc \
     && git submodule update --init --recursive
 RUN cd grpc \
     && mkdir -p cmake/build \
@@ -58,35 +58,35 @@ ENV LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH}
 FROM grpc-googleapis AS nuance-asr-grpc-api
 WORKDIR /usr/local/src
 ENV LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH}
-RUN git clone --depth 1 --branch main https://github.com/drachtio/nuance-asr-grpc-api.git \
+RUN git clone --depth 1 -b main https://github.com/drachtio/nuance-asr-grpc-api.git \
     && cd nuance-asr-grpc-api \
     && LANGUAGE=cpp make
 
 FROM grpc-googleapis AS riva-asr-grpc-api
 WORKDIR /usr/local/src
 ENV LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH}
-RUN git clone --depth 1 --branch main https://github.com/drachtio/riva-asr-grpc-api.git \
+RUN git clone --depth 1 -b main https://github.com/drachtio/riva-asr-grpc-api.git \
     && cd riva-asr-grpc-api \
     && LANGUAGE=cpp make
 
 FROM grpc-googleapis AS soniox-asr-grpc-api
 WORKDIR /usr/local/src
 ENV LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH}
-RUN git clone --depth 1 --branch main https://github.com/drachtio/soniox-asr-grpc-api.git \
+RUN git clone --depth 1 -b main https://github.com/drachtio/soniox-asr-grpc-api.git \
     && cd soniox-asr-grpc-api \
     && LANGUAGE=cpp make
 
 FROM grpc-googleapis AS cobalt-asr-grpc-api
 WORKDIR /usr/local/src
 ENV LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH}
-RUN git clone --depth 1 --branch main https://github.com/drachtio/cobalt-asr-grpc-api.git \
+RUN git clone --depth 1 -b main https://github.com/drachtio/cobalt-asr-grpc-api.git \
     && cd cobalt-asr-grpc-api \
     && LANGUAGE=cpp make
         
 FROM base-cmake AS websockets
 WORKDIR /usr/local/src
 ENV LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH}
-RUN git clone --depth 1 https://github.com/warmcat/libwebsockets.git -b v$LIBWEBSOCKETS_VERSION \
+RUN git clone --depth 1 -b v$LIBWEBSOCKETS_VERSION https://github.com/warmcat/libwebsockets.git \
     && cd /usr/local/src/libwebsockets \
     && mkdir -p build && cd build && cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo && make && make install
 
@@ -103,7 +103,7 @@ RUN tar xvfz SpeechSDK-Linux-$SPEECH_SDK_VERSION.tar.gz \
 
 FROM base AS freeswitch-modules
 WORKDIR /usr/local/src
-RUN git clone --depth 1 https://github.com/jambonz/freeswitch-modules.git -b $FREESWITCH_MODULES_VERSION
+RUN git clone --depth 1 -b $FREESWITCH_MODULES_VERSION https://github.com/jambonz/freeswitch-modules.git
 
 FROM base AS spandsp
 WORKDIR /usr/local/src
@@ -114,7 +114,7 @@ RUN git clone https://github.com/freeswitch/spandsp.git && cd spandsp && git che
 FROM base AS sofia-sip
 WORKDIR /usr/local/src
 ENV LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH}
-RUN git clone --depth 1 https://github.com/freeswitch/sofia-sip.git -b v$SOFIA_VERSION \
+RUN git clone --depth 1 -b v$SOFIA_VERSION https://github.com/freeswitch/sofia-sip.git \
     && cd sofia-sip \
     && ./bootstrap.sh && ./configure && make -j ${BUILD_CPUS} && make install
 
@@ -128,7 +128,7 @@ RUN git clone --depth 1 https://github.com/dpirch/libfvad.git \
 FROM base-cmake AS aws-sdk-cpp
 WORKDIR /usr/local/src
 ENV LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH}
-RUN git clone --depth 1 https://github.com/aws/aws-sdk-cpp.git -b $AWS_SDK_CPP_VERSION \
+RUN git clone --depth 1 -b $AWS_SDK_CPP_VERSION https://github.com/aws/aws-sdk-cpp.git \
     && cd aws-sdk-cpp \
     && git submodule update --init --recursive
 RUN cd /usr/local/src/aws-sdk-cpp \
@@ -169,7 +169,7 @@ COPY --from=websockets /usr/local/include/ /usr/local/include/
 COPY --from=websockets /usr/local/lib/ /usr/local/lib/
 WORKDIR /usr/local/src
 ENV LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH}
-RUN git clone --depth 1 https://github.com/signalwire/freeswitch.git -b v$FREESWITCH_VERSION
+RUN git clone -b v$FREESWITCH_VERSION https://github.com/signalwire/freeswitch.git
 COPY --from=freeswitch-modules /usr/local/src/freeswitch-modules/ /usr/local/src/freeswitch/src/mod/applications/
 COPY --from=nuance-asr-grpc-api /usr/local/src/nuance-asr-grpc-api /usr/local/src/freeswitch/libs/nuance-asr-grpc-api
 COPY --from=riva-asr-grpc-api /usr/local/src/riva-asr-grpc-api /usr/local/src/freeswitch/libs/riva-asr-grpc-api

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG BUILD_CPUS=1
 ## # this will be populated from the vaule in .env file
 ARG CMAKE_VERSION 
 ARG GRPC_VERSION
-ARG WEBSOCKETS_VERSION
+ARG LIBWEBSOCKETS_VERSION
 ARG SPEECH_SDK_VERSION
 ARG SPANDSP_VERSION
 ARG SOFIA_VERSION
@@ -86,7 +86,7 @@ RUN git clone --depth 1 --branch main https://github.com/drachtio/cobalt-asr-grp
 FROM base-cmake AS websockets
 WORKDIR /usr/local/src
 ENV LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH}
-RUN git clone --depth 1 --branch v$WEBSOCKETS_VERSION https://github.com/warmcat/libwebsockets.git \
+RUN git clone --depth 1 https://github.com/warmcat/libwebsockets.git -b v$LIBWEBSOCKETS_VERSION \
     && cd /usr/local/src/libwebsockets \
     && mkdir -p build && cd build && cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo && make && make install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN export CMAKE_VERSION=$CMAKE_VERSION \
 
 FROM base-cmake AS grpc
 WORKDIR /usr/local/src
-RUN git clone --depth 1 --branch v$GRPC_VERSION https://github.com/grpc/grpc && cd grpc \
+RUN git clone --depth 1 https://github.com/grpc/grpc -b v$GRPC_VERSION && cd grpc \
     && git submodule update --init --recursive
 RUN cd grpc \
     && mkdir -p cmake/build \

--- a/README.md
+++ b/README.md
@@ -187,3 +187,11 @@ This is the modules.conf.xml file in the image which dictates which modules get 
   </modules>
 </configuration>
 ```
+
+# Build image locally
+
+Docker build command does not natively support reading variable from `.env` file. Use the following command to build the docker image locally
+
+```bash
+sh build-locally.sh
+```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # docker-drachtio-freeswitch-mrf
 
-A slim Freeswitch 1.8 image (~127 MB) designed for use with [drachtio-fsmrf](http://davehorton.github.io/drachtio-fsmrf/), based on the [docker-drachtio-freeswitch-base](https://hub.docker.com/r/drachtio/drachtio-freeswitch-base/) image.
+A slim Freeswitch 1.10 image (~620 MB) designed for use with [drachtio-fsmrf](http://davehorton.github.io/drachtio-fsmrf/), based on the [docker-drachtio-freeswitch-base](https://hub.docker.com/r/drachtio/drachtio-freeswitch-base/) image.
 
 To run with default options:
 ```bash

--- a/build-locally.sh
+++ b/build-locally.sh
@@ -8,7 +8,7 @@ fi
 
 cmakeVersion=$(grep cmakeVersion .env | awk -F '=' '{print $2}')
 grpcVersion=$(grep grpcVersion .env | awk -F '=' '{print $2}')
-websocketsVersion=$(grep websocketsVersion .env | awk -F '=' '{print $2}')
+libwebsocketsVersion=$(grep libwebsocketsVersion .env | awk -F '=' '{print $2}')
 speechSdkVersion=$(grep speechSdkVersion .env | awk -F '=' '{print $2}')
 spandspVersion=$(grep spandspVersion .env | awk -F '=' '{print $2}')
 sofiaVersion=$(grep sofiaVersion .env | awk -F '=' '{print $2}')
@@ -19,7 +19,7 @@ freeswitchVersion=$(grep freeswitchVersion .env | awk -F '=' '{print $2}')
 docker build \
   --build-arg CMAKE_VERSION="${cmakeVersion}" \
   --build-arg GRPC_VERSION="${grpcVersion}" \
-  --build-arg WEBSOCKETS_VERSION="${websocketsVersion}" \
+  --build-arg LIBWEBSOCKETS_VERSION="${libwebsocketsVersion}" \
   --build-arg SPEECH_SDK_VERSION="${speechSdkVersion}" \
   --build-arg SPANDSP_VERSION="${spandspVersion}" \
   --build-arg SOFIA_VERSION="${sofiaVersion}" \

--- a/build-locally.sh
+++ b/build-locally.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Check if .env file exists
+if [ ! -f ".env" ]; then
+  echo "Error: .env file not found"
+  exit 1
+fi
+
+cmakeVersion=$(grep cmakeVersion .env | awk -F '=' '{print $2}')
+grpcVersion=$(grep grpcVersion .env | awk -F '=' '{print $2}')
+websocketsVersion=$(grep websocketsVersion .env | awk -F '=' '{print $2}')
+speechSdkVersion=$(grep speechSdkVersion .env | awk -F '=' '{print $2}')
+spandspVersion=$(grep spandspVersion .env | awk -F '=' '{print $2}')
+sofiaVersion=$(grep sofiaVersion .env | awk -F '=' '{print $2}')
+awsSdkCppVersion=$(grep awsSdkCppVersion .env | awk -F '=' '{print $2}')
+freeswitchModulesVersion=$(grep freeswitchModulesVersion .env | awk -F '=' '{print $2}')
+freeswitchVersion=$(grep freeswitchVersion .env | awk -F '=' '{print $2}')
+
+docker build \
+  --build-arg CMAKE_VERSION="${cmakeVersion}" \
+  --build-arg GRPC_VERSION="${grpcVersion}" \
+  --build-arg WEBSOCKETS_VERSION="${websocketsVersion}" \
+  --build-arg SPEECH_SDK_VERSION="${speechSdkVersion}" \
+  --build-arg SPANDSP_VERSION="${spandspVersion}" \
+  --build-arg SOFIA_VERSION="${sofiaVersion}" \
+  --build-arg AWS_SDK_CPP_VERSION="${awsSdkCppVersion}" \
+  --build-arg FREESWITCH_MODULES_VERSION="${freeswitchModulesVersion}" \
+  --build-arg FREESWITCH_VERSION="${freeswitchVersion}" \
+  .


### PR DESCRIPTION
This PR is centralizing all used versions / tags / branches from the `Dockerfile` into a dedicated `.env` file.

It should no longer be required to touch the dockerfile to update any of the used libraries and dependencies.

In addition I added a bash script `build-locally.sh` to build the image locally and added a section to the README. 

Included version updates:
- freeswitch to `1.10.11`
- sofia-sip to `1.13.17`
- aws-sdk-cpp to `1.11.345`
- `gRPC` to `1.64.2`

I tested the build locally - that was working. Since I have no configured gitHub pipeline, could you please trigger a build? 