### PR TITLE
fix username in entrypoint

### DIFF
--- a/.env
+++ b/.env
@@ -11,3 +11,6 @@ sofiaVersion=1.13.17
 awsSdkCppVersion=1.11.345
 freeswitchModulesVersion=1.2.22
 freeswitchVersion=1.10.11
+
+dockerImageRepo=drachtio-freeswitch-mrf
+dockerImageVersion=latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ### 0.9.2 (2024-09-13)
-- fix replacement in `entrypoint.sh` to set the `Mediaserver` name via `--username`
+- fix replacement in `entrypoint.sh` to set the `Mediaserver` name correctly via `--username`
 - improve `build-locally.sh` and add a tag to the docker image with `repo:version` from `.env` file
 
 ### 0.9.1 (2024-06-08)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 0.9.2 (2024-09-13)
+- fix replacement in `entrypoint.sh` to set the `Mediaserver` name via `--username`
+- improve `build-locally.sh` and add a tag to the docker image with `repo:version` from `.env` file
+
 ### 0.9.1 (2024-06-08)
 - update `freeswitch` to `1.10.11`
   - this changes the `sofia-sip` library requirement to version `1.13.17`

--- a/build-locally.sh
+++ b/build-locally.sh
@@ -16,6 +16,9 @@ awsSdkCppVersion=$(grep awsSdkCppVersion .env | awk -F '=' '{print $2}')
 freeswitchModulesVersion=$(grep freeswitchModulesVersion .env | awk -F '=' '{print $2}')
 freeswitchVersion=$(grep freeswitchVersion .env | awk -F '=' '{print $2}')
 
+dockerImageRepo=$(grep dockerImageRepo .env | awk -F '=' '{print $2}')
+dockerImageVersion=$(grep dockerImageVersion .env | awk -F '=' '{print $2}')
+
 docker build \
   --build-arg CMAKE_VERSION="${cmakeVersion}" \
   --build-arg GRPC_VERSION="${grpcVersion}" \
@@ -26,4 +29,4 @@ docker build \
   --build-arg AWS_SDK_CPP_VERSION="${awsSdkCppVersion}" \
   --build-arg FREESWITCH_MODULES_VERSION="${freeswitchModulesVersion}" \
   --build-arg FREESWITCH_VERSION="${freeswitchVersion}" \
-  .
+  . --tag "${dockerImageRepo}:${dockerImageVersion}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -103,7 +103,8 @@ while :; do
 
   --username)
     if [ -n "$2" ]; then
-      sed -i -e "s/name=\"username\" value=\"Jambonz\"/name=\"username\" value=\"$2\"/g" /usr/local/freeswitch/conf/sip_profiles/mrf.xml
+      sed -i -e 's/value="Jambonz-Mediaserver"/value="'$2'-Mediaserver"/g' /usr/local/freeswitch/conf/sip_profiles/mrf.xml
+    fi
     fi
     shift
     shift

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -105,7 +105,6 @@ while :; do
     if [ -n "$2" ]; then
       sed -i -e 's/value="Jambonz-Mediaserver"/value="'$2'-Mediaserver"/g' /usr/local/freeswitch/conf/sip_profiles/mrf.xml
     fi
-    fi
     shift
     shift
     ;;


### PR DESCRIPTION
username replacement does not work


Goal: set `username` via args and get it applied via entrypoint.sh 

```
# example args: 
freeswitch --username FreeSWITCH --log-level debug

# exec into freeswitch:
`cat /usr/local/freeswitch/conf/sip_profiles/mrf.xml | grep Mediaserver`
=> <param name="username" value="Jambonz-Mediaserver"/>

# Expected 
=> <param name="username" value="FreeSWITCH-Mediaserver"/>
```


How to test: 

1. exec into the freeswitch pod
2. run the command `sed -i -e 's/value="Jambonz-Mediaserver"/value="'FreeSWITCH'-Mediaserver"/g' /usr/local/freeswitch/conf/sip_profiles/mrf.xml`
3. `cat /usr/local/freeswitch/conf/sip_profiles/mrf.xml | grep Mediaserver`
4. => `<param name="username" value="FreeSWITCH-Mediaserver"/>`
