### PR TITLE
Update libs, freeswitch, fs-modules, grpc, aws, azure, cmake

### DIFF
--- a/.env
+++ b/.env
@@ -2,15 +2,32 @@
 ## Literal values after the equal sign will be passed to the docker build command
 ## and docker build does not support any quotes in image tag.
 
-cmakeVersion=3.30.3					# https://cmake.org/files/v3.30/
-grpcVersion=1.66.1					# https://github.com/grpc/grpc/releases
-libwebsocketsVersion=4.3.3			# https://github.com/warmcat/libwebsockets/tags
-speechSdkVersion=1.40.0				# https://aka.ms/csspeech/linuxbinary
-spandspVersion=0d2e6ac 				# https://github.com/freeswitch/spandsp/commit/0d2e6ac65e0e8f53d652665a743015a88bf048d4
-sofiaVersion=1.13.17				# https://github.com/freeswitch/sofia-sip/releases
-awsSdkCppVersion=1.11.409			# https://github.com/aws/aws-sdk-cpp/tags 
-freeswitchModulesVersion=1.2.30		# https://github.com/jambonz/freeswitch-modules/tags
-freeswitchVersion=1.10.12			# https://github.com/signalwire/freeswitch/releases
+# https://cmake.org/download/#latest
+cmakeVersion=3.30.3
 
-dockerImageRepo=drachtio-freeswitch-mrf
+# https://github.com/grpc/grpc/releases
+grpcVersion=1.66.1
+
+# https://github.com/warmcat/libwebsockets/tags
+libwebsocketsVersion=4.3.3
+
+# https://aka.ms/csspeech/linuxbinary
+speechSdkVersion=1.40.0
+
+# https://github.com/freeswitch/spandsp/commit/0d2e6ac65e0e8f53d652665a743015a88bf048d4
+spandspVersion=0d2e6ac
+
+# https://github.com/freeswitch/sofia-sip/releases
+sofiaVersion=1.13.17
+
+# https://github.com/aws/aws-sdk-cpp/tags 
+awsSdkCppVersion=1.11.409
+
+# https://github.com/jambonz/freeswitch-modules/tags
+freeswitchModulesVersion=1.2.30
+
+# https://github.com/signalwire/freeswitch/releases
+freeswitchVersion=1.10.12
+
+dockerImageRepo=cognigydevelopment.azurecr.io/vg-freeswitch-mrf
 dockerImageVersion=latest

--- a/.env
+++ b/.env
@@ -29,5 +29,5 @@ freeswitchModulesVersion=1.2.30
 # https://github.com/signalwire/freeswitch/releases
 freeswitchVersion=1.10.12
 
-dockerImageRepo=cognigydevelopment.azurecr.io/vg-freeswitch-mrf
+dockerImageRepo=drachtio-freeswitch-mrf
 dockerImageVersion=latest

--- a/.env
+++ b/.env
@@ -2,15 +2,15 @@
 ## Literal values after the equal sign will be passed to the docker build command
 ## and docker build does not support any quotes in image tag.
 
-cmakeVersion=3.28.3
-grpcVersion=1.64.2
-libwebsocketsVersion=4.3.3
-speechSdkVersion=1.37.0
-spandspVersion=0d2e6ac # https://github.com/freeswitch/spandsp/commit/0d2e6ac65e0e8f53d652665a743015a88bf048d4
-sofiaVersion=1.13.17
-awsSdkCppVersion=1.11.345
-freeswitchModulesVersion=1.2.22
-freeswitchVersion=1.10.11
+cmakeVersion=3.30.3					# https://cmake.org/files/v3.30/
+grpcVersion=1.66.1					# https://github.com/grpc/grpc/releases
+libwebsocketsVersion=4.3.3			# https://github.com/warmcat/libwebsockets/tags
+speechSdkVersion=1.40.0				# https://aka.ms/csspeech/linuxbinary
+spandspVersion=0d2e6ac 				# https://github.com/freeswitch/spandsp/commit/0d2e6ac65e0e8f53d652665a743015a88bf048d4
+sofiaVersion=1.13.17				# https://github.com/freeswitch/sofia-sip/releases
+awsSdkCppVersion=1.11.409			# https://github.com/aws/aws-sdk-cpp/tags 
+freeswitchModulesVersion=1.2.30		# https://github.com/jambonz/freeswitch-modules/tags
+freeswitchVersion=1.10.12			# https://github.com/signalwire/freeswitch/releases
 
 dockerImageRepo=drachtio-freeswitch-mrf
 dockerImageVersion=latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+### 0.9.3 (2024-09-20)
+- update `freeswitch-modules` to `1.2.30`
+- update `freeswitch` to `1.10.12`
+  - [mod_event_socket] Check if listener is running before pushing more logs or events to its queue
+  - [mod_opus] Fix status returned by switch_opus_decode(). Should be SWITCH_STATUS_FALSE instead of SWITCH_STATUS_NOOP. Add a unit-test.
+  - [mod_sofia] Set missing CF_3PCC flag
+- update `cmake` to `3.30.3`
+- update `gRPC` to `1.66.1`
+- update `azure speech sdk` to `1.40.0`
+- update `aws-sdk-cpp` to `1.11.409`
+
 ### 0.9.2 (2024-09-13)
 - fix replacement in `entrypoint.sh` to set the `Mediaserver` name correctly via `--username`
 - improve `build-locally.sh` and add a tag to the docker image with `repo:version` from `.env` file

--- a/build-locally.sh
+++ b/build-locally.sh
@@ -7,6 +7,8 @@ if [ ! -f ".env" ]; then
 fi
 
 cmakeVersion=$(grep cmakeVersion .env | awk -F '=' '{print $2}')
+echo $cmakeVersion
+
 grpcVersion=$(grep grpcVersion .env | awk -F '=' '{print $2}')
 libwebsocketsVersion=$(grep libwebsocketsVersion .env | awk -F '=' '{print $2}')
 speechSdkVersion=$(grep speechSdkVersion .env | awk -F '=' '{print $2}')

--- a/build-locally.sh
+++ b/build-locally.sh
@@ -7,8 +7,6 @@ if [ ! -f ".env" ]; then
 fi
 
 cmakeVersion=$(grep cmakeVersion .env | awk -F '=' '{print $2}')
-echo $cmakeVersion
-
 grpcVersion=$(grep grpcVersion .env | awk -F '=' '{print $2}')
 libwebsocketsVersion=$(grep libwebsocketsVersion .env | awk -F '=' '{print $2}')
 speechSdkVersion=$(grep speechSdkVersion .env | awk -F '=' '{print $2}')


### PR DESCRIPTION
This PR updates:

- update `freeswitch-modules` to `1.2.30`
- update `freeswitch` to `1.10.12`
  - [mod_event_socket] Check if listener is running before pushing more logs or events to its queue
  - [mod_opus] Fix status returned by switch_opus_decode(). Should be SWITCH_STATUS_FALSE instead of SWITCH_STATUS_NOOP. Add a unit-test.
  - [mod_sofia] Set missing CF_3PCC flag
- update `cmake` to `3.30.3`
- update `gRPC` to `1.66.1`
- update `azure speech sdk` to `1.40.0`
- update `aws-sdk-cpp` to `1.11.409`

In addition, all referenced repos are linked in the .env file for an easier check for new releases